### PR TITLE
Add enum for VideoPlcmtSubtype

### DIFF
--- a/proto/com/iabtechlab/adcom/v1/enums/enums.proto
+++ b/proto/com/iabtechlab/adcom/v1/enums/enums.proto
@@ -618,6 +618,40 @@ enum VideoPlacementSubtype {
 
 
 /**
+ * The following table lists the various types of video placements in accordance with updated IAB
+ * Digital Video Guidelines. To be sent using plcmt attribute in Object:Video.
+ */
+enum VideoPlcmtSubtype {
+  VideoPlcmtSubtype_UNKNOWN = 0;  // Equivalent to an unset value.
+
+  // Instream: Pre-roll, mid-roll, and post-roll ads that are played before, during or after the
+  // streaming video content that the consumer has requested. Instream video must be set to "sound
+  // on" by default at player start, or have explicitly clear user intent to watch the video
+  // content. While there may be other content surrounding the player, the video content must be the
+  // focus of the user's visit. It should remain the primary content on the page and the only video
+  // player in-view capable of audio when playing. If the player converts to floating/sticky
+  // subsequent ad calls should accurately convey the updated player size.
+  INSTREAM = 1;
+
+  // Accompanying Content: Pre-roll, mid-roll, and post-roll ads that are played before, during, or
+  // after streaming video content. The video player loads and plays before, between, or after
+  // paragraphs of text or graphical content, and starts playing only when it enters the viewport.
+  // Accompanying content should only start playback upon entering the viewport. It may convert to a
+  // floating/sticky player as it scrolls off the page.
+  ACCOMPANYING_CONTENT = 2;
+
+  // Interstitial: Video ads that are played without video content. During playback, it must be the
+  // primary focus of the page and take up the majority of the viewport and cannot be scrolled out
+  // of view. This can be in placements like in-app video or slideshows.
+  INTERSTITIAL = 3;
+
+  // No Content/Standalone: Video ads that are played without streaming video content. This can be
+  // in placements like slideshows, native feeds, in-content or sticky/floating.
+  STANDALONE = 4;
+}
+
+
+/**
  * The following enum defines the various modes for when media playback terminates.
  */
 enum PlaybackCessationMode {


### PR DESCRIPTION
As defined in https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/develop/AdCOM%20v1.0%20FINAL.md#list_plcmtsubtypesvideo.