### PR TITLE
Disambiguate "plcmt" enum names from existing names

### DIFF
--- a/proto/com/iabtechlab/adcom/v1/enums/enums.proto
+++ b/proto/com/iabtechlab/adcom/v1/enums/enums.proto
@@ -631,23 +631,23 @@ enum VideoPlcmtSubtype {
   // focus of the user's visit. It should remain the primary content on the page and the only video
   // player in-view capable of audio when playing. If the player converts to floating/sticky
   // subsequent ad calls should accurately convey the updated player size.
-  INSTREAM = 1;
+  INSTREAM_PLCMT = 1;
 
   // Accompanying Content: Pre-roll, mid-roll, and post-roll ads that are played before, during, or
   // after streaming video content. The video player loads and plays before, between, or after
   // paragraphs of text or graphical content, and starts playing only when it enters the viewport.
   // Accompanying content should only start playback upon entering the viewport. It may convert to a
   // floating/sticky player as it scrolls off the page.
-  ACCOMPANYING_CONTENT = 2;
+  ACCOMPANYING_CONTENT_PLCMT = 2;
 
   // Interstitial: Video ads that are played without video content. During playback, it must be the
   // primary focus of the page and take up the majority of the viewport and cannot be scrolled out
   // of view. This can be in placements like in-app video or slideshows.
-  INTERSTITIAL = 3;
+  INTERSTITIAL_PLCMT = 3;
 
   // No Content/Standalone: Video ads that are played without streaming video content. This can be
   // in placements like slideshows, native feeds, in-content or sticky/floating.
-  STANDALONE = 4;
+  STANDALONE_PLCMT = 4;
 }
 
 


### PR DESCRIPTION
The legacy `VideoPlacementSubtype` enum already had `INTERSTITIAL`, so we're not allowed to re-use that in `VideoPlcmtSubtype`.